### PR TITLE
Add caching on database connection and get_data() function [runs every 30 minutes]

### DIFF
--- a/overall.py
+++ b/overall.py
@@ -9,52 +9,58 @@ from google.cloud import firestore
 from google.oauth2 import service_account
 import json
 
+@st.cache_resource # Caches the connection to the database
+def get_database(key_data):
+    creds = service_account.Credentials.from_service_account_info(key_data)
+    db = firestore.Client(credentials=creds)
+    return db
+
+@st.cache_data(ttl = 1800) # Caches the updates and forces an update every 30 minutes
+def get_data(_db):
+    # Create a reference to the Google post.
+    doc_ref = _db.collection('master_data')
+
+    # Create dictionary that will be used to create dataframe
+    data_dict = { "Form Name": [], "Timestamp": [], "Course Rating": [], 
+    "Guidelines Before": [], "Guidelines After": [], "Improvement Efforts": [], 
+    "Sharing Interest": [], "Instructor Rating": [], "Accessibility Rating": [], 
+    "Navigation Rating": [], "Current Profession": [], "Student Count": [], "Student Location": []}
+
+    # Iterate through every document in the collection and append each value to the dictionary
+    for doc in doc_ref.stream():
+        data = doc.to_dict()
+        data_dict["Form Name"].append(data["form_name"])
+        data_dict["Timestamp"].append(data["timestamp"])
+        data_dict["Course Rating"].append(data["course_rating"])
+        data_dict["Guidelines Before"].append(data["guidelines_before"])
+        data_dict["Guidelines After"].append(data["guidelines_after"])
+        data_dict["Improvement Efforts"].append(data["improvement_efforts"])
+        data_dict["Sharing Interest"].append(data["sharing_interest"])
+        data_dict["Instructor Rating"].append(data["instructor_rating"])
+        data_dict["Accessibility Rating"].append(data["accessibility_rating"])
+        data_dict["Navigation Rating"].append(data["navigation_rating"])
+        data_dict["Current Profession"].append(data["current_profession"])
+        data_dict["Student Count"].append(data["student_count"])
+        data_dict["Student Location"].append(data["student_location"])
+
+    # for i in data_dict:
+    #     print(i)
+    #     print(len(data_dict[i]))
+
+    return pd.DataFrame(data_dict)
+
+
 # Set page title and favicon
 st.set_page_config(page_title="Homepage", page_icon="assets/EENC-logo.png", layout="wide")
 
 # Authenticate to Firestore with the JSON account key.
 key_dict = json.loads(st.secrets['textkey'])
-creds = service_account.Credentials.from_service_account_info(key_dict)
-db = firestore.Client(credentials=creds)
-
-# Create a reference to the Google post.
-doc_ref = db.collection('master_data')
-
-# Create dictionary that will be used to create dataframe
-data_dict = { "Form Name": [], "Timestamp": [], "Course Rating": [], 
-"Guidelines Before": [], "Guidelines After": [], "Improvement Efforts": [], 
-"Sharing Interest": [], "Instructor Rating": [], "Accessibility Rating": [], 
-"Navigation Rating": [], "Current Profession": [], "Student Count": [], "Student Location": []}
-
-# Iterate through every document in the collection and append each value to the dictionary
-for doc in doc_ref.stream():
-    data = doc.to_dict()
-    data_dict["Form Name"].append(data["form_name"])
-    data_dict["Timestamp"].append(data["timestamp"])
-    data_dict["Course Rating"].append(data["course_rating"])
-    data_dict["Guidelines Before"].append(data["guidelines_before"])
-    data_dict["Guidelines After"].append(data["guidelines_after"])
-    data_dict["Improvement Efforts"].append(data["improvement_efforts"])
-    data_dict["Sharing Interest"].append(data["sharing_interest"])
-    data_dict["Instructor Rating"].append(data["instructor_rating"])
-    data_dict["Accessibility Rating"].append(data["accessibility_rating"])
-    data_dict["Navigation Rating"].append(data["navigation_rating"])
-    data_dict["Current Profession"].append(data["current_profession"])
-    data_dict["Student Count"].append(data["student_count"])
-    data_dict["Student Location"].append(data["student_location"])
-
-# for i in data_dict:
-#     print(i)
-#     print(len(data_dict[i]))
-
-final_data = pd.DataFrame(data_dict)
-
-if "master_data" not in st.session_state:
-    st.session_state["master_data"] = final_data
+st.session_state["database_connection"] = get_database(key_dict)
+st.session_state["master_data"] = get_data(st.session_state["database_connection"])
+print(st.session_state["master_data"])
 
 # Load the data
 data = pd.read_csv("data/data.csv")
-print(st.session_state["master_data"])
 
 # logo
 st.image("assets/EENC-logo.png", width=100)


### PR DESCRIPTION
Used the @st.cache_resource and @st.cache_data decorator to mark the database connection and get data functions. The database connection will only run once when the Overall page is loaded in and also loads in the data. The data will be cached and added to the streamlit session but will be forcefully updated every 30 minutes through the ttl=1800 argument in the @st.cache_data() decorator.